### PR TITLE
Add a default null client validator

### DIFF
--- a/src/NpmWeb/ClientValidationGenerator/Laravel/HtmlServiceProvider.php
+++ b/src/NpmWeb/ClientValidationGenerator/Laravel/HtmlServiceProvider.php
@@ -27,7 +27,11 @@ class HtmlServiceProvider extends \Collective\Html\HtmlServiceProvider {
 	 * Sets up the client validation generator instance
 	 */
 	protected function createClientValidationGenerator($app) {
-		return $app->make('client-validation');
+		if( $app->bound('client-validation') ) {
+			return $app->make('client-validation');
+		} else {
+			return new NullClientValidationGenerator;
+		}
 	}
 
 }

--- a/src/NpmWeb/ClientValidationGenerator/NullClientValidationGenerator.php
+++ b/src/NpmWeb/ClientValidationGenerator/NullClientValidationGenerator.php
@@ -1,0 +1,12 @@
+<?php namespace NpmWeb\ClientValidationGenerator;
+
+class NullClientValidationGenerator implements ClientValidationGeneratorInterface {
+
+  public function generateClientValidatorCode( $rules, $formId, array $options = null ) {
+    return "";
+  }
+
+  public function getCodePosition() {
+    return START;
+  }
+}


### PR DESCRIPTION
This addresses an issue where Laravel form builders (such as npmweb/laravel-forms) that extend the Client Validation Generator form builder may not want to use client validation, but they will error out without a validator. This adds a default null validator that will be returned if no other validator is bound. This allows for such form builders to be used without including the ClientValidationServiceProvider.